### PR TITLE
import bootstrap to be used on any component

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,17 +1,19 @@
-import React from 'react';
-import ReactDOM from 'react-dom/client';
-import './index.css';
-import App from './App';
-import reportWebVitals from './reportWebVitals';
+import React from "react"
+import ReactDOM from "react-dom/client"
+import "./index.css"
+import App from "./App"
+// Importing the Bootstrap CSS
+import "bootstrap/dist/css/bootstrap.min.css"
+// import reportWebVitals from "./reportWebVitals"
 
-const root = ReactDOM.createRoot(document.getElementById('root'));
+const root = ReactDOM.createRoot(document.getElementById("root"))
 root.render(
   <React.StrictMode>
     <App />
   </React.StrictMode>
-);
+)
 
 // If you want to start measuring performance in your app, pass a function
 // to log results (for example: reportWebVitals(console.log))
 // or send to an analytics endpoint. Learn more: https://bit.ly/CRA-vitals
-reportWebVitals();
+// reportWebVitals()


### PR DESCRIPTION
I noticed we needed to import bootstrap and the bootstrap component for every component we will be working on.
So I set up the import on index.js that way we need to only import the bootstrap component.