### PR TITLE
Week 3: query messages by timestamp to render recent messages first

### DIFF
--- a/src/components/MiddleChatWindow.js
+++ b/src/components/MiddleChatWindow.js
@@ -1,25 +1,19 @@
 import { db } from "../config/fire-config"
-import { collection, onSnapshot } from "firebase/firestore"
-import { useState, useEffect } from "react"
+import { collection, onSnapshot, query, orderBy } from "firebase/firestore"
+import { useState } from "react"
 import React from "react"
 
 
 function MiddleChatWindow() {
   const [messages, setMessages] = useState([])
   const messagesCollectionRef = collection(db, "messages")
+  const queryMessages = query(messagesCollectionRef, orderBy("timestamp"))
   
-  useEffect(() => {
-    // captures data
-    const getMessages = async () => {
-     await onSnapshot(messagesCollectionRef, function(snapshot) {
-      setMessages(snapshot.docs.map((doc) => ({ ...doc.data(), id: doc.id })))
+  // captures data
+  onSnapshot(queryMessages, function(snapshot) {
+    setMessages(snapshot.docs.map((doc) => ({ ...doc.data(), id: doc.id })))
     })
-    
-  }
-  
-  getMessages()
-  }, [])
-  
+
   return (
     <>
     <ul>


### PR DESCRIPTION
-rendering messages in timestamp order allows users to view recent message first (and not older message)
-onSnapshot() does the role of useEffect(), so we don't need useEffect()

"You can listen to a document with the onSnapshot() method. An initial call using the callback you provide creates a document snapshot immediately with the current contents of the single document. Then, each time the contents change, another call updates the document snapshot."