### PR TITLE
fix memory leak onSnapshot function

### DIFF
--- a/src/components/LeftSideComponent.js
+++ b/src/components/LeftSideComponent.js
@@ -1,17 +1,28 @@
 import { db } from "../config/fire-config"
-import { collection, onSnapshot, query, orderBy } from "firebase/firestore"
-import { useState } from "react"
+import {
+  collection,
+  onSnapshot,
+  query,
+  orderBy,
+  limit,
+} from "firebase/firestore"
+import { useState, useEffect } from "react"
 
 // Component renders list on currently logged in users in application
 function LeftSideComponent() {
   const [users, setUsers] = useState([])
   const usersCollectionRef = collection(db, "users")
-  const queryMessages = query(usersCollectionRef, orderBy("name"))
+  const queryUsers = query(usersCollectionRef, orderBy("name"), limit(20))
 
-  // When user sign in on app, set user name and password on "users" collection. When user signs out remove user from "users" collection.
-  onSnapshot(queryMessages, function (snapshot) {
-    setUsers(snapshot.docs.map((doc) => ({ ...doc.data(), id: doc.id })))
-  })
+  const getUsers = () => {
+    onSnapshot(queryUsers, (snapshot) => {
+      setUsers(snapshot.docs.map((doc) => ({ ...doc.data(), id: doc.id })))
+    })
+  }
+
+  useEffect(() => {
+    getUsers()
+  }, [])
 
   return (
     <>

--- a/src/components/MiddleChatWindow.js
+++ b/src/components/MiddleChatWindow.js
@@ -1,27 +1,31 @@
 import { db } from "../config/fire-config"
 import { collection, onSnapshot, query, orderBy } from "firebase/firestore"
-import { useState } from "react"
-import React from "react"
-
+import { useState, useEffect } from "react"
 
 function MiddleChatWindow() {
   const [messages, setMessages] = useState([])
   const messagesCollectionRef = collection(db, "messages")
   const queryMessages = query(messagesCollectionRef, orderBy("timestamp"))
-  
+
   // captures data
-  onSnapshot(queryMessages, function(snapshot) {
-    setMessages(snapshot.docs.map((doc) => ({ ...doc.data(), id: doc.id })))
+  const getMessages = () => {
+    onSnapshot(queryMessages, function (snapshot) {
+      setMessages(snapshot.docs.map((doc) => ({ ...doc.data(), id: doc.id })))
     })
+  }
+
+  useEffect(() => {
+    getMessages()
+  }, [])
 
   return (
     <>
-    <ul>
-      {/* renders message */}
-      {messages.map((message) => {
-      return <li key={message.id}>{message.text}</li>
-          })}
-    </ul>
+      <ul>
+        {/* renders message */}
+        {messages.map((message) => {
+          return <li key={message.id}>{message.text}</li>
+        })}
+      </ul>
     </>
   )
 }

--- a/src/components/MiddleChatWindow.js
+++ b/src/components/MiddleChatWindow.js
@@ -9,7 +9,7 @@ function MiddleChatWindow() {
 
   // captures data
   const getMessages = () => {
-    onSnapshot(queryMessages, function (snapshot) {
+    onSnapshot(queryMessages, (snapshot) => {
       setMessages(snapshot.docs.map((doc) => ({ ...doc.data(), id: doc.id })))
     })
   }


### PR DESCRIPTION
- The function onSnapshot was triggering the component to re-render and causing another connection to the Firestore db which would then change the state of the component and cause another re-render. It created a memory leak making the browser kill the application to prevent a system crash.
- Adding useEffect ensures that onSnapshot is invoked only in the initial render.
- onSnapshot will still update the state whenever new data is available.



Using the React dev tools extension to visualize the issue:

Before:
![2022-08-14_10-08](https://user-images.githubusercontent.com/8095975/184540940-7777154a-0e66-4f42-908c-6886edbd058b.png)



After:
![2022-08-14_10-09](https://user-images.githubusercontent.com/8095975/184540948-1b50b64a-8581-4bac-aba5-09c9b6ce1983.png)



Closes #51 