### PR TITLE
Week05 fix white space

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,38 +1,3 @@
-
-
-
-
-@media (prefers-reduced-motion: no-preference) {
-  .App-logo {
-    animation: App-logo-spin infinite 20s linear;
-  }
-}
-
-.App-header {
-  background-color: #282c34;
-  min-height: 100vh;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  font-size: calc(10px + 2vmin);
-  color: white;
-}
-
-.App-link {
-  color: #61dafb;
-}
-
-@keyframes App-logo-spin {
-  from {
-    transform: rotate(0deg);
-  }
-  to {
-    transform: rotate(360deg);
-  }
-}
-
-
 .list-group-item {
   background: #282c34;
 }

--- a/src/components/MiddleChatWindow.module.css
+++ b/src/components/MiddleChatWindow.module.css
@@ -1,7 +1,3 @@
-html {
-  box-sizing: content-box;
-  width: 100%;
-}
 .listGroup {
   margin: auto;
   list-style-type: none;

--- a/src/components/MiddleChatWindow.module.css
+++ b/src/components/MiddleChatWindow.module.css
@@ -1,11 +1,13 @@
 .listGroup {
-    list-style-type: none;
-    display: flex;
-        flex-direction: column;
-        justify-content: center;
-        text-decoration: none;
-        align-items: center;
-        background-color: #1A2930;
+  margin: auto;
+  list-style-type: none;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  text-decoration: none;
+  align-items: center;
+  background-color: #1A2930;
+  min-height: 100vh;
 }
 
 .listGroupItem {

--- a/src/components/MiddleChatWindow.module.css
+++ b/src/components/MiddleChatWindow.module.css
@@ -1,3 +1,7 @@
+html {
+  box-sizing: content-box;
+  width: 100%;
+}
 .listGroup {
   margin: auto;
   list-style-type: none;
@@ -7,7 +11,7 @@
   text-decoration: none;
   align-items: center;
   background-color: #1A2930;
-  min-height: 100vh;
+  height: 75vh;
 }
 
 .listGroupItem {

--- a/src/components/MiddleChatWindow.module.css
+++ b/src/components/MiddleChatWindow.module.css
@@ -7,7 +7,7 @@
   text-decoration: none;
   align-items: center;
   background-color: #1A2930;
-  height: 75vh;
+  height: 90vh;
 }
 
 .listGroupItem {


### PR DESCRIPTION
A previous PR was closed and the margin and height properties did not get added in MiddleChatWindow component causing lots of white space where the background color was not applied in the MiddleChatWindow component. 

The height  property was added for the desktop viewport so there would not be white space between the MiddleChatWindow component and the BottomInput component.

The App.css boilerplate code was also deleted for code cleanup. As it is not used in the chat app.

The chat app should now look like the screenshot below even if there are no messages to be displayed.
<img width="1075" alt="Screen Shot 2022-08-21 at 8 22 55 PM" src="https://user-images.githubusercontent.com/39227111/185833799-29451722-ea30-492b-9218-31b56472a01c.png">

