### PR TITLE
Week05 UI left side component

### DIFF
--- a/src/components/LeftSideComponent.css
+++ b/src/components/LeftSideComponent.css
@@ -14,4 +14,3 @@
   list-style-type: none;
   font-size: 1.75rem;
 }
-

--- a/src/components/LeftSideComponent.css
+++ b/src/components/LeftSideComponent.css
@@ -14,3 +14,24 @@
   list-style-type: none;
   font-size: 1.75rem;
 }
+.side-bar {
+  height: 100vh;
+  width: 86px;
+  padding-top: 125px;
+  padding-left: 20px;
+  position: fixed;
+  bottom: 0px;
+  left: auto;
+  z-index: 10;
+}
+ 
+/* styling for sidebar text */
+.sidebar-text {
+ list-style-type: none;
+ font-size: 1.75rem;
+}
+ 
+/*styling for x button*/
+.btn-close {
+ background-color: #fff !important;
+}


### PR DESCRIPTION
The `users` button is in better default postion.
<img width="199" alt="Screen Shot 2022-08-25 at 8 56 06 AM" src="https://user-images.githubusercontent.com/39227111/186713142-e0fbc173-612b-4a12-88f4-05424ad4b921.png">

The x button that appears in the offcanvas menu is more clearly visible.
<img width="732" alt="Screen Shot 2022-08-25 at 8 57 32 AM" src="https://user-images.githubusercontent.com/39227111/186713327-9754cc29-b7d4-438e-afb8-5580b1c2ac26.png">

