### PR TITLE
Week05 styling middlechat window

### DIFF
--- a/src/components/LeftSideComponent.css
+++ b/src/components/LeftSideComponent.css
@@ -1,8 +1,9 @@
-/* styling for sidebar component*/
+/* styling for sidebar component */
 .side-bar {
   height: 100vh;
   width: 86px;
-  padding-top: 80px;
+  padding-top: 125px;
+  padding-left: 20px;
   position: fixed;
   bottom: 0px;
   left: auto;
@@ -13,5 +14,10 @@
 .sidebar-text {
   list-style-type: none;
   font-size: 1.75rem;
+}
+
+/* styling for x button in offcanvas popmenu that appears when user clicks on users icon */
+.btn-close {
+ background-color: #fff !important;
 }
 

--- a/src/components/MiddleChatWindow.css
+++ b/src/components/MiddleChatWindow.css
@@ -7,6 +7,7 @@
   background-color: #1A2930;
   height: 90vh;
   overflow: scroll;
+  padding-left: 200px;
 }
 /* styling for each message displayed in chat window */
 .list-item {
@@ -14,8 +15,8 @@
   border-radius:10px;
   background-color: #e9ecef;
   width: 20em;
-  /* padding:1em; */
-  /* display: inline; */
+  padding: .5em 1em;
+  overflow-wrap: break-word;
   overflow-y: scroll;
 }
 

--- a/src/components/MiddleChatWindow.css
+++ b/src/components/MiddleChatWindow.css
@@ -24,7 +24,7 @@
 .profile-pic-and-message {
   display: flex;
   flex-direction: row;
-  padding-left: 80px;
+  align-items: flex-start;  
 }
 
 /* styling for the profile pic */

--- a/src/components/MiddleChatWindow.css
+++ b/src/components/MiddleChatWindow.css
@@ -17,7 +17,6 @@
   width: 20em;
   padding: .5em 1em;
   overflow-wrap: break-word;
-  overflow-y: scroll;
 }
 
 /* styling for the div that contains both profile pic and message */


### PR DESCRIPTION
Messages now have  `overflow-wrap: break-word;` property and container that holds messages and profile pic have   `align-items: flex-start;  ` property. This ensures the profile pics does not stretch with the width of the messages container distorting the user's profile picture.
<img width="455" alt="Screen Shot 2022-08-25 at 9 11 52 AM" src="https://user-images.githubusercontent.com/39227111/186717049-3d0efb94-b7ff-4133-8c5e-bdf64262581b.png">

