### PR TITLE
Week 5: disable button to prevent empty messages

### DIFF
--- a/src/components/BottomInputComponent.css
+++ b/src/components/BottomInputComponent.css
@@ -16,3 +16,11 @@
   font-size: 25px;
   width: 70%;
 }
+
+.wrapper {
+  cursor: not-allowed;
+}
+
+.pointer-events-none {
+  pointer-events: none;
+}

--- a/src/components/BottomInputComponent.js
+++ b/src/components/BottomInputComponent.js
@@ -37,7 +37,7 @@ function BottomInputComponent({ currentUser, isFocused }) {
     setMessage("")
   }
 
-  // Perform focus on input field's element via the DOM API when component renders/ dependency changes
+  // Perform focus on input field's element via the DOM API when component renders/dependency changes
   // (imperative approach)
   const inputRef = React.useRef()
 
@@ -63,16 +63,32 @@ function BottomInputComponent({ currentUser, isFocused }) {
           className='bottom-input-field'
           ref={inputRef}
         ></input>
-        <BsFillArrowUpSquareFill
-          type='button'
-          onClick={handleSubmitMessage}
-          style={{
-            color: "#3BBF69",
-            fontSize: "50px",
-            backgroundColor: "#1A2930",
-            borderRadius: "10px",
-          }}
-        />
+        {message.length === 0 ? (
+          <div className='wrapper'>
+            <BsFillArrowUpSquareFill
+              type='button'
+              disabled={true}
+              className='pointer-events-none'
+              style={{
+                color: "#3BBF69",
+                fontSize: "50px",
+                backgroundColor: "#1A2930",
+                borderRadius: "10px",
+              }}
+            />
+          </div>
+        ) : (
+          <BsFillArrowUpSquareFill
+            type='button'
+            onClick={handleSubmitMessage}
+            style={{
+              color: "#3BBF69",
+              fontSize: "50px",
+              backgroundColor: "#1A2930",
+              borderRadius: "10px",
+            }}
+          />
+        )}
       </form>
     </>
   )


### PR DESCRIPTION
closes #132 

If there are no messages detected (a user is not typing), disable button ('cursor not allowed' renders); otherwise, when a user is typing a message, enable button