### PR TITLE
Week05 fixed input on bottom, display messages from the bottom of screen, removed always displayed scrollbar

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -3,6 +3,4 @@
   width: 100%;
   padding-left: 0 !important;
   padding-right: 0 !important;
-  min-height: 75vh;
-  max-height: 100vh;
 }

--- a/src/components/BottomInputComponent.css
+++ b/src/components/BottomInputComponent.css
@@ -13,6 +13,6 @@
   margin-bottom: 20px;
   margin-right: 15px;
   border-radius: 10px !important;
-  font-size: 25px;
-  width: 70%;
+  font-size: 20px;
+  width: 80%;
 }

--- a/src/components/BottomInputComponent.css
+++ b/src/components/BottomInputComponent.css
@@ -2,8 +2,10 @@
 .bottom-input-form {
   display: flex;
   justify-content: center;
-  background-color: #1A2930;
   align-items: center;
+  flex-grow: 1;
+  flex-shrink: 1;
+  max-width: 750px;
 }
 
 /* styling for the input field */
@@ -15,4 +17,8 @@
   border-radius: 10px !important;
   font-size: 20px;
   width: 80%;
+}
+
+.container-bottom-input-form {
+  justify-content: center !important;
 }

--- a/src/components/BottomInputComponent.js
+++ b/src/components/BottomInputComponent.js
@@ -64,11 +64,12 @@ function BottomInputComponent({ currentUser, isFocused }) {
           ref={inputRef}
         ></input>
         <BsFillArrowUpSquareFill
+          className='bottom-input-form-button'
           type='button'
           onClick={handleSubmitMessage}
           style={{
             color: "#3BBF69",
-            fontSize: "50px",
+            fontSize: "44px",
             backgroundColor: "#1A2930",
             borderRadius: "10px",
           }}

--- a/src/components/BottomInputComponent.js
+++ b/src/components/BottomInputComponent.js
@@ -4,6 +4,8 @@ import { db } from "../config/fire-config"
 import { collection, addDoc, serverTimestamp } from "firebase/firestore"
 import "./BottomInputComponent.css"
 import { BsFillArrowUpSquareFill } from "react-icons/bs"
+import Container from "react-bootstrap/Container"
+import Navbar from "react-bootstrap/Navbar"
 
 function BottomInputComponent({ currentUser, isFocused }) {
   const [message, setMessage] = useState("")
@@ -50,32 +52,63 @@ function BottomInputComponent({ currentUser, isFocused }) {
 
   return (
     <>
-      <form
-        onSubmit={handleSubmitMessage}
-        className='bottom-input-form'
-        fixed='bottom'
-      >
-        <input
-          type='text'
-          value={message}
-          placeholder='Type something...'
-          onChange={handleMessageChange}
-          className='bottom-input-field'
-          ref={inputRef}
-        ></input>
-        <BsFillArrowUpSquareFill
-          className='bottom-input-form-button'
-          type='button'
-          onClick={handleSubmitMessage}
-          style={{
-            color: "#3BBF69",
-            fontSize: "44px",
-            backgroundColor: "#1A2930",
-            borderRadius: "10px",
-          }}
-        />
-      </form>
+      <Navbar fixed='bottom' bg='secondary'>
+        <Container className='container-bottom-input-form'>
+          <form
+            onSubmit={handleSubmitMessage}
+            className='bottom-input-form'
+            fixed='bottom'
+          >
+            <input
+              type='text'
+              value={message}
+              placeholder='Type something...'
+              onChange={handleMessageChange}
+              className='bottom-input-field'
+              ref={inputRef}
+            ></input>
+            <BsFillArrowUpSquareFill
+              className='bottom-input-form-button'
+              type='button'
+              onClick={handleSubmitMessage}
+              style={{
+                color: "#3BBF69",
+                fontSize: "44px",
+                backgroundColor: "#1A2930",
+                borderRadius: "10px",
+              }}
+            />
+          </form>
+        </Container>
+      </Navbar>
     </>
+    // <>
+    //   <form
+    //     onSubmit={handleSubmitMessage}
+    //     className='bottom-input-form'
+    //     fixed='bottom'
+    //   >
+    //     <input
+    //       type='text'
+    //       value={message}
+    //       placeholder='Type something...'
+    //       onChange={handleMessageChange}
+    //       className='bottom-input-field'
+    //       ref={inputRef}
+    //     ></input>
+    //     <BsFillArrowUpSquareFill
+    //       className='bottom-input-form-button'
+    //       type='button'
+    //       onClick={handleSubmitMessage}
+    //       style={{
+    //         color: "#3BBF69",
+    //         fontSize: "44px",
+    //         backgroundColor: "#1A2930",
+    //         borderRadius: "10px",
+    //       }}
+    //     />
+    //   </form>
+    // </>
   )
 }
 

--- a/src/components/BottomInputComponent.js
+++ b/src/components/BottomInputComponent.js
@@ -82,33 +82,6 @@ function BottomInputComponent({ currentUser, isFocused }) {
         </Container>
       </Navbar>
     </>
-    // <>
-    //   <form
-    //     onSubmit={handleSubmitMessage}
-    //     className='bottom-input-form'
-    //     fixed='bottom'
-    //   >
-    //     <input
-    //       type='text'
-    //       value={message}
-    //       placeholder='Type something...'
-    //       onChange={handleMessageChange}
-    //       className='bottom-input-field'
-    //       ref={inputRef}
-    //     ></input>
-    //     <BsFillArrowUpSquareFill
-    //       className='bottom-input-form-button'
-    //       type='button'
-    //       onClick={handleSubmitMessage}
-    //       style={{
-    //         color: "#3BBF69",
-    //         fontSize: "44px",
-    //         backgroundColor: "#1A2930",
-    //         borderRadius: "10px",
-    //       }}
-    //     />
-    //   </form>
-    // </>
   )
 }
 

--- a/src/components/Chat.js
+++ b/src/components/Chat.js
@@ -28,13 +28,7 @@ function Chat({ currentUser }) {
             </div>
             <div className='col-2'></div>
           </div>
-          <div className='row'>
-            <div className='col-2'></div>
-            <div className='col-8'>
-              <BottomInputComponent currentUser={currentUser} isFocused />
-            </div>
-            <div className='col-2'></div>
-          </div>
+          <BottomInputComponent currentUser={currentUser} isFocused />
         </div>
       </section>
     </>

--- a/src/components/Chat.js
+++ b/src/components/Chat.js
@@ -17,7 +17,7 @@ function Chat({ currentUser }) {
   return (
     <>
       <TopNavigationBar currentUser={currentUser} />
-      <section className='bg-secondary'>
+      <section className='bg-secondary min-vh-100'>
         <div className='container'>
           <div className='row'>
             <div className='col-2'>
@@ -26,12 +26,17 @@ function Chat({ currentUser }) {
             <div className='col-8'>
               <MiddleChatWindow currentUser={currentUser} />
             </div>
-              <div className='col-2'>
+            <div className='col-2'></div>
+          </div>
+          <div className='row'>
+            <div className='col-2'></div>
+            <div className='col-8'>
+              <BottomInputComponent currentUser={currentUser} isFocused />
             </div>
+            <div className='col-2'></div>
           </div>
         </div>
       </section>
-      <BottomInputComponent currentUser={currentUser} isFocused />
     </>
   )
 }

--- a/src/components/MiddleChatWindow.css
+++ b/src/components/MiddleChatWindow.css
@@ -3,10 +3,8 @@
   margin: auto;
   list-style-type: none;
   text-decoration: none;
-  background-color: #1A2930;
-  height: 90vh;
-  overflow: scroll;
-  padding-top: 150px;
+  padding-top: 125px;
+  flex-grow: 1;
 }
 /* styling for each message displayed in chat window */
 .list-item {

--- a/src/components/MiddleChatWindow.css
+++ b/src/components/MiddleChatWindow.css
@@ -4,7 +4,9 @@
   list-style-type: none;
   text-decoration: none;
   padding-top: 125px;
-  flex-grow: 1;
+  padding-bottom: 100px;
+  min-height: 100vh;
+  flex-direction: column-reverse;
 }
 /* styling for each message displayed in chat window */
 .list-item {

--- a/src/components/MiddleChatWindow.js
+++ b/src/components/MiddleChatWindow.js
@@ -6,7 +6,10 @@ import "./MiddleChatWindow.css"
 function MiddleChatWindow({ currentUser }) {
   const [messages, setMessages] = useState([])
   const messagesCollectionRef = collection(db, "messages")
-  const queryMessages = query(messagesCollectionRef, orderBy("timestamp"))
+  const queryMessages = query(
+    messagesCollectionRef,
+    orderBy("timestamp", "desc")
+  )
 
   // captures data
   const getMessages = () => {
@@ -21,7 +24,7 @@ function MiddleChatWindow({ currentUser }) {
 
   return (
     <>
-      <ul className='list-container'>
+      <ul className='list-container d-flex'>
         {/* renders message */}
         {messages.map((message) => {
           return (


### PR DESCRIPTION
Closes #123 

- Fixed the input field in the bottom of the screen;
- add container to use 100% of vh;
- display messages from the bottom first;
- order messages by timestamp 'desc';
- bottom bar is responsive and will shrink in size on smaller screens;

https://user-images.githubusercontent.com/8095975/186951723-116e18f7-e05b-41ad-a81d-6f9c79bce941.mp4


We still have a problem where once we have enough messages to fill the screen it will not automatically scroll down.


https://user-images.githubusercontent.com/8095975/186951951-0f6e9837-57e0-42b7-8278-3892633ced51.mp4


