### PR TITLE
Week06 - Fixes scroll behavior when new message is sent

### DIFF
--- a/src/components/MiddleChatWindow.js
+++ b/src/components/MiddleChatWindow.js
@@ -1,10 +1,9 @@
 import { db } from "../config/fire-config"
 import { collection, onSnapshot, query, orderBy } from "firebase/firestore"
-import { useState, useEffect, useContext } from "react"
+import { useState, useEffect, useContext, useRef, useMemo } from "react"
 import "./MiddleChatWindow.css"
 import { ThemeContext } from "../context.js"
 import UserLogo from "../assets/sparrow-user-profile.svg"
-
 
 function MiddleChatWindow({ currentUser }) {
   const [messages, setMessages] = useState([])
@@ -14,20 +13,55 @@ function MiddleChatWindow({ currentUser }) {
     orderBy("timestamp", "desc")
   )
   const { theme } = useContext(ThemeContext)
+  const screenBottom = useRef(null)
+  const lastMessageIsInViewport = useIsInViewport(screenBottom)
 
   // captures data
   const getMessages = () => {
     onSnapshot(queryMessages, (snapshot) => {
       setMessages(snapshot.docs.map((doc) => ({ ...doc.data(), id: doc.id })))
-      window.scrollBy(0, 1000)
     })
   }
 
+  function useIsInViewport(ref) {
+    const [isIntersecting, setIsIntersecting] = useState(false)
+
+    const observer = useMemo(
+      () =>
+        new IntersectionObserver(
+          ([entry]) => {
+            setIsIntersecting(entry.isIntersecting)
+          },
+          {
+            rootMargin: "20px",
+          }
+        ),
+      []
+    )
+
+    useEffect(() => {
+      observer.observe(ref.current)
+
+      return () => {
+        observer.disconnect()
+      }
+    }, [ref, observer])
+
+    return isIntersecting
+  }
+
+  const scrollToBottom = () => {
+    screenBottom.current?.scrollIntoView({ behavior: "smooth" })
+  }
+
+  useEffect(() => {
+    if (lastMessageIsInViewport) {
+      scrollToBottom()
+    }
+  }, [messages])
+
   useEffect(() => {
     getMessages()
-    setTimeout(() => {
-      window.scrollBy(0, 100000)
-    }, 500)
   }, [])
 
   return (
@@ -36,6 +70,8 @@ function MiddleChatWindow({ currentUser }) {
         className='list-container d-flex list-unstyled'
         style={{ backgroundColor: theme.primary }}
       >
+        {/* div to check if last message is in viewport */}
+        <div ref={screenBottom}></div>
         {/* renders message */}
         {messages.map((message) => {
           const name = `${message.name.split(" ")[0]} ${
@@ -55,7 +91,7 @@ function MiddleChatWindow({ currentUser }) {
               <img
                 className='user-image'
                 // Conditional statement for profile image
-                src={message ? message.profilePicUrl : ''}
+                src={message ? message.profilePicUrl : ""}
                 width='75'
                 alt='profile pic'
               />


### PR DESCRIPTION
Closes #143 

Using a reference to the last message I was able to set an Intersection Observer to check if the last message is in the viewport.

If the reference is not in the viewport the autoscroll for new messages is not executed.

https://user-images.githubusercontent.com/8095975/188198932-d3d9030d-aeae-485d-bec5-c1236100d6e2.mp4

