### PR TITLE
Week 7: Add description to icons when hover over for accessibility purposes

### DIFF
--- a/src/components/BottomInputComponent.js
+++ b/src/components/BottomInputComponent.js
@@ -110,6 +110,7 @@ function BottomInputComponent({ currentUser, isFocused }) {
                   border: "1px solid #fff",
                   borderRadius: "0 10px 10px 0",
                 }}
+                title='Send message'
               />
             )}
           </form>

--- a/src/components/LeftSideComponent.js
+++ b/src/components/LeftSideComponent.js
@@ -45,6 +45,7 @@ function LeftSideComponent({ name, ...props }) {
           style={{
             color: "#2B2B2B",
           }}
+          title='Users logged in'
         />
       </div>
       <Offcanvas
@@ -57,6 +58,7 @@ function LeftSideComponent({ name, ...props }) {
         <Offcanvas.Header
           closeButton
           style={{ backgroundColor: theme.primary }}
+          title='Close'
         >
           <Offcanvas.Title style={{ color: theme.light }}>
             Users: {users.length}

--- a/src/components/TopNavigationBar.js
+++ b/src/components/TopNavigationBar.js
@@ -69,6 +69,7 @@ function TopNavigationBar({ currentUser }) {
               width='35'
               height='35'
               className='filter-grey'
+              title='Toggle light/dark mode'
             />
           </Button>
         </Container>


### PR DESCRIPTION
closes #173 

- to help users understand/navigate what an interactive icon does, I added a text description when a user hovers over the icon or button for accessibility purposes

![describe-toggle](https://user-images.githubusercontent.com/14948113/188325651-db98d249-3c3b-4add-886d-4ce9980e6d28.png)
![describe-user-icon](https://user-images.githubusercontent.com/14948113/188325657-50e0ec7c-cb89-4b3c-83e5-167849a1b916.png)
![describe-close-button](https://user-images.githubusercontent.com/14948113/188325662-504c8d7b-1a29-4612-8536-9c3dc5b0c9ef.png)
![describe-send-button](https://user-images.githubusercontent.com/14948113/188325666-a27f3005-7d98-4ab4-937b-2556394a88a5.png)

Side note: you'll naturally be able to see your pointer cursor when you hover over the interactive icons/button, however, when I took a screenshot of above images, the pointer cursor would disable given I took a screenshot.