### PR TITLE
Week 8: Style + provide responsiveness to sign-in & sign-up forms

### DIFF
--- a/src/components/SignIn.css
+++ b/src/components/SignIn.css
@@ -1,25 +1,27 @@
-/* color applied to sparrow logo */
-.filterYellow {
+/* outline color applied to sparrow logo */
+.filter-yellow {
   filter: invert(84%) sepia(81%) saturate(2592%) hue-rotate(323deg) brightness(101%) contrast(94%);
 }
 /* sign in container */
 .sign-in-container {
   min-height: 100vh;
-  width: 50%;
-  margin: 0 auto;
   display: flex;
   flex-direction: column;
   justify-content: center;
   align-items: center;
+  margin: 0 auto;
+  width: 40%;
 }
+
 .sign-in-form-section {
-  /* padding: 15px; */
-  width: 100%;
+  width: 60%;
 }
 .sign-in-text, .sign-in-text:hover {
   color: #fff;
-  text-decoration: none;
+  text-align: center;
+  margin-bottom: 2px;
 }
+
 .submit-btn {
   margin-top: 10px;
   margin-bottom: 25px;
@@ -30,7 +32,7 @@
 }
 /* section that links user to sign up for account */
 .link-text {
-  text-align: center;
+  text-decoration: none;
 }
 /* applies bold font weight */
 .font-weight-bold {
@@ -38,8 +40,37 @@
   padding: 20px 0 15px 0;
 }
 /* media queries */
-@media (max-width: 576px) {
+@media (max-width: 1370px) {
+  .sign-up-form-section {
+    width: 100%;
+  }
+}
+
+ @media (max-width: 1215px) {
   .sign-in-container {
+    width: 50%;
+  }
+  .sign-up-form-section {
+    width: 100%;
+   }
+ }
+
+ @media (max-width: 900px) {
+   .sign-in-container {
+     width: 60%;
+   }
+
+   .sign-up-form-section {
+     width: 100%;
+   }
+ }
+
+ @media (max-width: 700px) {
+  .sign-in-container {
+    width: 100%;
+   }
+  .sign-up-form-section {
     width: 100%;
   }
  }
+

--- a/src/components/SignIn.js
+++ b/src/components/SignIn.js
@@ -38,93 +38,93 @@ function SignIn({
   }, [])
 
   return (
-    <ThemeProvider
-      breakpoints={["xxxl", "xxl", "xl", "lg", "md", "sm", "xs", "xxs"]}
-      minBreakpoint='xxs'
-    >
-      <div>
-        <div className='bg-primary sign-in-container'>
-          {isLoading ? (
-            <>
+    <div>
+      {!isLoading ? (
+        <ThemeProvider
+          breakpoints={["xxxl", "xxl", "xl", "lg", "md", "sm", "xs", "xxs"]}
+          minBreakpoint='xxs'
+        >
+          <div className='bg-secondary'>
+            <div className='sign-in-container bg-primary'>
               <img
                 src={logo}
-                className='filterYellow'
-                style={{ height: 75, width: 75 }}
+                className='filter-yellow bird-logo'
+                style={{ height: 55, width: 55 }}
                 alt='Sparrow Logo'
               />
-              <h1 className='h6 text-warning'>sparrow</h1>
-              <img
-                src={spinner}
-                style={{ height: 75, width: 75 }}
-                alt='Loading Spinner'
-              />
-            </>
-          ) : (
-            <>
-              <Container className='sign-in-container'>
-                <div className='sign-in-form-section'>
-                  <img
-                    src={logo}
-                    className='filterYellow bird-logo'
-                    style={{ height: 75, width: 75 }}
-                    alt='Sparrow Logo'
-                  />
-                  <h1 className='h6 text-warning'>sparrow</h1>
-                  <h2 className='sign-in-text font-weight-bold'>Sign In</h2>
-                  <Form onSubmit={handleSubmit}>
-                    <Form.Group className='mb-3' controlId='formBasicEmail'>
-                      <Form.Label className='sign-in-text'>
-                        Email address
-                      </Form.Label>
-                      <Form.Control
-                        type='email'
-                        placeholder='Enter email'
-                        value={email}
-                        onChange={onEmailChange}
-                      />
-                    </Form.Group>
-                    <Form.Group className='mb-3' controlId='formBasicPassword'>
-                      <Form.Label className='sign-in-text'>Password</Form.Label>
-                      <Form.Control
-                        type='password'
-                        placeholder='Password'
-                        value={password}
-                        onChange={onPasswordChange}
-                      />
-                    </Form.Group>
-                    <Form.Group
-                      className='mb-3'
-                      controlId='formBasicCheckbox'
-                    ></Form.Group>
-                    <Button
-                      variant='info'
-                      type='submit'
-                      className='w-100 rounded-pill submit-btn'
-                    >
-                      Submit
-                    </Button>
-                    <br />
-                    <Button
-                      variant='info'
-                      onClick={() => {
-                        handleIsLoadingStateChange(true)
-                        signInWithGoogle(handleIsLoadingStateChange)
-                      }}
-                      className='px-4 rounded-pill bg-info w-100 google-btn'
-                    >
-                      Sign in with <i className='bi bi-google'></i>
-                    </Button>
-                    <Link to='/SignUp' className='sign-in-text link-text'>
-                      <p>Don't Have An Account? Sign Up With Email</p>
+              <h1 className='h6 text-warning ms-2 pb-4'>sparrow</h1>
+              <h2 className='sign-in-text font-weight-bold'>Sign In</h2>
+              <div className='sign-in-form-section'>
+                <Form onSubmit={handleSubmit}>
+                  <Form.Group className='mb-3' controlId='formBasicEmail'>
+                    <Form.Label className='sign-in-text'>Email</Form.Label>
+                    <Form.Control
+                      type='email'
+                      placeholder='Enter email'
+                      value={email}
+                      onChange={onEmailChange}
+                    />
+                  </Form.Group>
+                  <Form.Group className='mb-3' controlId='formBasicPassword'>
+                    <Form.Label className='sign-in-text'>Password</Form.Label>
+                    <Form.Control
+                      type='password'
+                      placeholder='Password'
+                      value={password}
+                      onChange={onPasswordChange}
+                    />
+                  </Form.Group>
+                  <Button
+                    variant='light'
+                    type='submit'
+                    className='bg-info w-100 rounded-pill submit-btn'
+                  >
+                    Submit
+                  </Button>
+                  <br />
+                  <Button
+                    variant='light'
+                    onClick={() => {
+                      handleIsLoadingStateChange(true)
+                      signInWithGoogle(handleIsLoadingStateChange)
+                    }}
+                    className='px-4 rounded-pill bg-info w-100 google-btn'
+                  >
+                    Sign in with <i className='bi bi-google'></i>
+                  </Button>
+                  <p className='sign-in-text'>Don't have an account?</p>
+                  <p className='sign-in-text'>
+                    {" "}
+                    Sign up with
+                    <Link to='/SignUp' className='link-text text-warning'>
+                      {" "}
+                      Email
                     </Link>
-                  </Form>
-                </div>
-              </Container>
-            </>
-          )}
+                  </p>
+                </Form>
+              </div>
+            </div>
+          </div>
+        </ThemeProvider>
+      ) : (
+        <div className='bg-secondary'>
+          <div className='sign-in-container bg-primary'>
+            <img
+              src={logo}
+              className='filter-yellow bird-logo'
+              style={{ height: 75, width: 75 }}
+              alt='Sparrow Logo'
+            />
+            <h1 className='h6 text-warning'>sparrow</h1>
+            <img
+              src={spinner}
+              style={{ height: 75, width: 75 }}
+              alt='Loading Spinner'
+            />
+          </div>
         </div>
-      </div>
-    </ThemeProvider>
+      )}
+    </div>
   )
 }
 

--- a/src/components/SignUp.css
+++ b/src/components/SignUp.css
@@ -1,34 +1,34 @@
+/* outline color applied to sparrow logo */
+.filter-yellow {
+  filter: invert(84%) sepia(81%) saturate(2592%) hue-rotate(323deg) brightness(101%) contrast(94%);
+}
+
 /* sign up container */
 .sign-up-container {
-  /* border: 1px solid red; */
-  width: 100%;
-  /* margin: 0 auto; */
-  height: 100vh;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-}
-/* sign up form */
-.sign-up-form-section {
-  padding: 15px;
-  width: 50%;
-  color: #202020;
-  display: flex;
   min-height: 100vh;
   display: flex;
   justify-content: center;
-  align-content: center;
+  align-items: center;
   flex-direction: column;
+  margin: 0 auto;
+  width: 50%;
+}
+/* sign up form */
+.sign-up-form-section {
+  width: 65%;
 }
 /* styling for form text */
 .sign-up-text {
   color: #fff;
+  text-align: center;
+}
+.sign-up-btn {
+  margin-top: 10px;
+  margin-bottom: 20px;
 }
 /* styling for text linking to sign in page */
 .link-text {
-  padding-top: 10px;
-  text-align: center;
+  text-decoration: none;
 }
 /* styling for header */
 .font-weight-bold {
@@ -36,8 +36,14 @@
   padding: 20px 0 15px 0;
 }
 /* media queries */
-@media (max-width: 576px) {
-  .sign-up-form-section {
-    width: 100%;
+@media (max-width: 1000px) {
+  .sign-up-container {
+    width: 75%;
   }
+ }
+
+ @media (max-width: 770px) {
+   .sign-up-container {
+     width: 100%;
+   }
  }

--- a/src/components/SignUp.js
+++ b/src/components/SignUp.js
@@ -30,64 +30,67 @@ function SignUp() {
       breakpoints={["xxxl", "xxl", "xl", "lg", "md", "sm", "xs", "xxs"]}
       minBreakpoint='xxs'
     >
-      <Container className='sign-up-container' fluid>
-        <div className='sign-up-form-section bg-primary'>
+      <Container className='bg-secondary'>
+        <div className='bg-primary sign-up-container'>
           <img
             src={logo}
-            className='filterYellow'
-            style={{ height: 75, width: 75 }}
+            className='filter-yellow'
+            style={{ height: 55, width: 55 }}
             alt='Sparrow Logo'
           />
-          <h1 className='h6 text-warning'>sparrow</h1>
-          <Form onSubmit={handleSubmit}>
-            <h2 className='sign-up-text font-weight-bold'>Sign Up</h2>
-            <Form.Group className='mb-3' controlId='formBasicName'>
-              <Form.Label className='sign-up-text'>Enter Name</Form.Label>
-              <Form.Control
-                value={user.firstName}
-                type='name'
-                name='name'
-                placeholder='Enter name'
-                onChange={handleChange}
-              />
-            </Form.Group>
-            <Form.Group className='mb-3' controlId='formBasicEmail'>
-              <Form.Label className='sign-up-text'>Email address</Form.Label>
-              <Form.Control
-                value={user.email}
-                type='email'
-                name='email'
-                placeholder='Enter email'
-                onChange={handleChange}
-              />
-            </Form.Group>
+          <h1 className='h6 text-warning ms-2 pb-4'>sparrow</h1>
+          <div className='sign-up-form-section'>
+            <Form onSubmit={handleSubmit}>
+              <h2 className='sign-up-text font-weight-bold'>Sign Up</h2>
+              <Form.Group className='mb-3' controlId='formBasicName'>
+                <Form.Label className='sign-up-text'>Name</Form.Label>
+                <Form.Control
+                  value={user.firstName}
+                  type='name'
+                  name='name'
+                  placeholder='Enter name'
+                  onChange={handleChange}
+                />
+              </Form.Group>
+              <Form.Group className='mb-3' controlId='formBasicEmail'>
+                <Form.Label className='sign-up-text'>Email</Form.Label>
+                <Form.Control
+                  value={user.email}
+                  type='email'
+                  name='email'
+                  placeholder='Enter email'
+                  onChange={handleChange}
+                />
+              </Form.Group>
+              <Form.Group className='mb-3' controlId='formBasicPassword'>
+                <Form.Label className='sign-up-text'>Password</Form.Label>
+                <Form.Control
+                  value={user.password}
+                  type='password'
+                  name='password'
+                  placeholder='Password'
+                  onChange={handleChange}
+                />
+              </Form.Group>
 
-            <Form.Group className='mb-3' controlId='formBasicPassword'>
-              <Form.Label className='sign-up-text'>Password</Form.Label>
-              <Form.Control
-                value={user.password}
-                type='password'
-                name='password'
-                placeholder='Password'
-                onChange={handleChange}
-              />
-            </Form.Group>
-            <Form.Group
-              className='mb-3'
-              controlId='formBasicCheckbox'
-            ></Form.Group>
-            <Button
-              disabled={loading}
-              variant='info'
-              type='submit'
-              className='rounded-pill w-100 sign-up-btn'
-            >
-              Sign Up
-            </Button>
-            <Link to='/'>
-              <p className='sign-up-text link-text'>Have an account? Sign in</p>
-            </Link>
-          </Form>
+              <Button
+                disabled={loading}
+                variant='light'
+                type='submit'
+                className='bg-info rounded-pill w-100 sign-up-btn'
+              >
+                Sign Up
+              </Button>
+
+              <p className='sign-up-text'>
+                Have an account?
+                <Link to='/' className='link-text text-warning'>
+                  {" "}
+                  Sign In
+                </Link>
+              </p>
+            </Form>
+          </div>
         </div>
       </Container>
     </ThemeProvider>


### PR DESCRIPTION
closes #188 

- centered logo & title
- provided a precise link to only "Email" & "Sign In" -> no longer links the whole text
- added color to these links (our yellow wireframe color)
- outlined buttons to provide a bit of a pop
- provided some responsiveness (work in progress)
- removed JSX elements not in use 
- cleaned up styling properties

desktop version
![desktop-sign-in-version](https://user-images.githubusercontent.com/14948113/190668722-81fd90b3-5731-4e7e-9b4b-c588f585c5ca.png)

version for smaller screens
![sign-in-version](https://user-images.githubusercontent.com/14948113/190668473-a119119e-a5d9-4a02-87c8-313f18ede516.png)
