### PR TITLE
Name rendered visual fix.

### DIFF
--- a/src/components/MiddleChatWindow.js
+++ b/src/components/MiddleChatWindow.js
@@ -24,7 +24,7 @@ function MiddleChatWindow({ currentUser, messages, screenBottom }) {
             //if username contains a space then format second text with period if there is more than one character or just return the second character with no period
           } else if (message.name.includes(" ")) {
             name = `${message.name.split(" ")[0]} ${
-              message.name.split(" ")[1]
+              message.name.split(" ")[1][0]
             }.`
             //by default return user name
           } else {


### PR DESCRIPTION
The else if statement in MiddleChatWindow is now similar to previous logic where last name gets split and a period gets added.
<img width="117" alt="Screen Shot 2022-09-18 at 8 49 34 AM" src="https://user-images.githubusercontent.com/39227111/190916018-60084cd8-1ce9-4324-9cd7-1816e4e9ae32.png">
