### PR TITLE
Adding media query to 500px

### DIFF
--- a/src/components/MiddleChatWindow.css
+++ b/src/components/MiddleChatWindow.css
@@ -52,3 +52,10 @@
 /* .list-item-name {
   padding-right: 30px; 
 } */
+
+/* media queries */
+ @media (max-width: 500px) {
+  .user-image {
+    width: 35px;
+  }
+ }


### PR DESCRIPTION
At 500px screen size the profile pic in text message window shrinks to 25px.
<img width="433" alt="Screen Shot 2022-09-19 at 2 32 36 PM" src="https://user-images.githubusercontent.com/39227111/191123757-5f63f41e-4a05-4092-b8ec-28ddc0cc75dd.png">
